### PR TITLE
add instructions for installing dependencies using UV

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ Then
 source .venv/bin/activate
 ```
 
+### Installing Dependencies
+Install the required dependencies using UV:
+```sh
+uv sync --all-extras
+```
+
 ## Making Contributions
 
 ### Coding Standards


### PR DESCRIPTION
Adding missing step in `contributing.md` file. using `uv run X` is not required when you already included step where you activate  the virtual environment. I didn't remove it because I thought you might have kept it for a specific purpose.