### PR TITLE
fix Python 3.9 and 3.10 compatibility issues

### DIFF
--- a/crudadmin/admin_interface/admin_site.py
+++ b/crudadmin/admin_interface/admin_site.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import AsyncGenerator, Callable
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, cast
 
 from fastapi import APIRouter, Cookie, Depends, Request, Response
@@ -18,6 +18,8 @@ from ..session.schemas import SessionData
 from ..session.storage import AbstractSessionStorage, get_session_storage
 from .auth import AdminAuthentication
 from .typing import RouteResponse
+
+UTC = timezone.utc
 
 logger = logging.getLogger(__name__)
 

--- a/crudadmin/admin_interface/crud_admin.py
+++ b/crudadmin/admin_interface/crud_admin.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
     AsyncGenerator,
@@ -42,6 +42,8 @@ from ..session.storage import AbstractSessionStorage, get_session_storage
 from .admin_site import AdminSite
 from .model_view import ModelView
 from .typing import RouteResponse
+
+UTC = timezone.utc
 
 logger = logging.getLogger("crudadmin")
 

--- a/crudadmin/admin_interface/crud_admin.py
+++ b/crudadmin/admin_interface/crud_admin.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
@@ -10,12 +11,16 @@ from typing import (
     List,
     Optional,
     Type,
-    TypeAlias,
     TypedDict,
     TypeVar,
     Union,
     cast,
 )
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.security import OAuth2PasswordBearer

--- a/crudadmin/admin_user/models.py
+++ b/crudadmin/admin_user/models.py
@@ -1,8 +1,10 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Optional, Type
 
 from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+UTC = timezone.utc
 
 
 def create_admin_user(base: Type[DeclarativeBase]) -> Type[DeclarativeBase]:

--- a/crudadmin/core/schemas/timestamp.py
+++ b/crudadmin/core/schemas/timestamp.py
@@ -1,7 +1,9 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_serializer
+
+UTC = timezone.utc
 
 
 class TimestampSchema(BaseModel):

--- a/crudadmin/core/schemas/timestamp.py
+++ b/crudadmin/core/schemas/timestamp.py
@@ -11,15 +11,15 @@ class TimestampSchema(BaseModel):
     updated_at: Optional[datetime] = Field(default=None)
 
     @field_serializer("created_at")
-    def serialize_dt(self, created_at: datetime | None, _info: Any) -> str | None:
+    def serialize_dt(self, created_at: Optional[datetime], _info: Any) -> Optional[str]:
         if created_at is not None:
             return created_at.isoformat()
         return None
 
     @field_serializer("updated_at")
     def serialize_updated_at(
-        self, updated_at: datetime | None, _info: Any
-    ) -> str | None:
+        self, updated_at: Optional[datetime], _info: Any
+    ) -> Optional[str]:
         if updated_at is not None:
             return updated_at.isoformat()
         return None

--- a/crudadmin/event/decorators.py
+++ b/crudadmin/event/decorators.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Type
 
 from fastapi import Request
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 
 from .models import EventType
+
+UTC = timezone.utc
 
 logger = logging.getLogger(__name__)
 

--- a/crudadmin/event/models.py
+++ b/crudadmin/event/models.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Optional, cast
 
 from sqlalchemy import JSON, DateTime, String
@@ -6,6 +6,8 @@ from sqlalchemy import Enum as SQLEnum
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from .schemas import EventStatus, EventType
+
+UTC = timezone.utc
 
 
 def create_admin_event_log(base: type[DeclarativeBase]) -> type[DeclarativeBase]:

--- a/crudadmin/event/service.py
+++ b/crudadmin/event/service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Optional, cast
@@ -18,6 +18,8 @@ from .schemas import (
     EventStatus,
     EventType,
 )
+
+UTC = timezone.utc
 
 logger = logging.getLogger(__name__)
 

--- a/crudadmin/session/backends/database.py
+++ b/crudadmin/session/backends/database.py
@@ -6,7 +6,7 @@ dashboard for session management and monitoring.
 """
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -15,6 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ...core.db import DatabaseConfig
 from ..schemas import AdminSessionCreate, AdminSessionUpdate
 from ..storage import AbstractSessionStorage
+
+UTC = timezone.utc
 
 T = TypeVar("T", bound=BaseModel)
 logger = logging.getLogger(__name__)

--- a/crudadmin/session/backends/memory.py
+++ b/crudadmin/session/backends/memory.py
@@ -1,12 +1,14 @@
 import json
 import logging
 import re
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Pattern, TypeVar
 
 from pydantic import BaseModel
 
 from ..storage import AbstractSessionStorage
+
+UTC = timezone.utc
 
 T = TypeVar("T", bound=BaseModel)
 logger = logging.getLogger(__name__)

--- a/crudadmin/session/manager.py
+++ b/crudadmin/session/manager.py
@@ -1,6 +1,6 @@
 import logging
 import secrets
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, Optional
 
 from fastapi import Request, Response
@@ -9,6 +9,8 @@ from ..core.rate_limiter import SimpleRateLimiter
 from .schemas import CSRFToken, SessionCreate, SessionData, UserAgentInfo
 from .storage import AbstractSessionStorage, get_session_storage
 from .user_agents_types import parse
+
+UTC = timezone.utc
 
 logger = logging.getLogger(__name__)
 

--- a/crudadmin/session/models.py
+++ b/crudadmin/session/models.py
@@ -1,8 +1,10 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import JSON, Boolean, DateTime, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+UTC = timezone.utc
 
 
 def create_admin_session_model(base: type[DeclarativeBase]) -> type[DeclarativeBase]:

--- a/crudadmin/session/schemas.py
+++ b/crudadmin/session/schemas.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
 from uuid import uuid4
@@ -6,6 +6,8 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, field_validator
 
 from ..core.schemas.timestamp import TimestampSchema
+
+UTC = timezone.utc
 
 
 class DeviceType(str, Enum):

--- a/tests/auth/test_endpoints.py
+++ b/tests/auth/test_endpoints.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,6 +6,8 @@ from fastapi import HTTPException, Request, status
 
 from crudadmin.session.manager import SessionManager
 from crudadmin.session.schemas import SessionData
+
+UTC = timezone.utc
 
 
 class CSRFException(HTTPException):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Type
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -33,6 +33,8 @@ from crudadmin.event.service import EventService
 from crudadmin.session.manager import SessionManager
 from crudadmin.session.schemas import SessionData
 from crudadmin.session.storage import get_session_storage
+
+UTC = timezone.utc
 
 
 class Base(DeclarativeBase):

--- a/tests/event/test_service.py
+++ b/tests/event/test_service.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from unittest.mock import ANY, AsyncMock, Mock, patch
@@ -13,6 +13,8 @@ from crudadmin.event.schemas import (
     EventType,
 )
 from crudadmin.event.service import CustomJSONEncoder, EventService
+
+UTC = timezone.utc
 
 
 class SampleEnum(Enum):

--- a/tests/session/test_integration.py
+++ b/tests/session/test_integration.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +7,8 @@ from fastapi import Response
 from crudadmin.session.manager import SessionManager
 from crudadmin.session.schemas import CSRFToken, SessionData, UserAgentInfo
 from crudadmin.session.storage import get_session_storage
+
+UTC = timezone.utc
 
 
 class TestSessionManagerIntegration:

--- a/tests/session/test_manager.py
+++ b/tests/session/test_manager.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -6,6 +6,8 @@ import pytest
 from crudadmin.session.manager import SessionManager
 from crudadmin.session.schemas import SessionData
 from crudadmin.session.storage import get_session_storage
+
+UTC = timezone.utc
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes compatibility issues for Python 3.9 and 3.10 support:

- Replace `datetime.UTC` with `timezone.utc` (UTC constant only available in Python 3.11+, affects 3.9 and 3.10)
- Add conditional import for `TypeAlias` with fallback to `typing_extensions` for Python 3.9 (`TypeAlias` only available in Python 3.10+)
- Replace union syntax `X | None` with `Optional[X]` for Python 3.9 compatibility

These changes ensure the package works correctly on Python >= 3.9 as specified in `pyproject.toml`.