### PR TITLE
add matrix testing for multiple Python versions in test workflow 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
         - uses: actions/checkout@v4
@@ -12,7 +15,7 @@ jobs:
         - name: Install uv and set the python version
           uses: astral-sh/setup-uv@v5
           with:
-            python-version: "3.11"
+            python-version: ${{ matrix.python-version }}
             enable-cache: true
             cache-dependency-glob: "uv.lock"
   


### PR DESCRIPTION
This PR improves the CI testing workflow by adding a matrix strategy to test against the supported Python versions, i.e., 3.9, 3.10, 3.11, and 3.12. This ensures better compatibility across different Python versions and helps catch version-specific issues early.