### PR TITLE
Fix(UI): correct dashboard URLs when mounted at root

### DIFF
--- a/crudadmin/admin_interface/admin_site.py
+++ b/crudadmin/admin_interface/admin_site.py
@@ -248,7 +248,7 @@ class AdminSite:
                         {
                             "request": request,
                             "error": "Invalid credentials. Please try again.",
-                            "mount_path": self.mount_path,
+                            "url_prefix": self.get_url_prefix(),
                             "theme": self.theme,
                         },
                     )
@@ -301,7 +301,7 @@ class AdminSite:
                         {
                             "request": request,
                             "error": f"Error creating session: {str(e)}",
-                            "mount_path": self.mount_path,
+                            "url_prefix": self.get_url_prefix(),
                             "theme": self.theme,
                         },
                     )
@@ -313,7 +313,7 @@ class AdminSite:
                     {
                         "request": request,
                         "error": "An error occurred during login. Please try again.",
-                        "mount_path": self.mount_path,
+                        "url_prefix": self.get_url_prefix(),
                         "theme": self.theme,
                     },
                 )
@@ -397,7 +397,7 @@ class AdminSite:
                 "auth/login.html",
                 {
                     "request": request,
-                    "mount_path": self.mount_path,
+                    "url_prefix": self.get_url_prefix(),
                     "theme": self.theme,
                     "error": error,
                 },
@@ -477,7 +477,7 @@ class AdminSite:
             "table_names": self.models.keys(),
             "auth_model_counts": auth_model_counts,
             "model_counts": model_counts,
-            "mount_path": self.mount_path,
+            "url_prefix": self.get_url_prefix(),
             "track_events": self.event_integration is not None,
             "theme": self.theme,
         }

--- a/crudadmin/admin_interface/crud_admin.py
+++ b/crudadmin/admin_interface/crud_admin.py
@@ -627,7 +627,7 @@ class CRUDAdmin:
                     "event_types": [e.value for e in EventType],
                     "statuses": [s.value for s in EventStatus],
                     "users": users["data"],
-                    "mount_path": self.mount_path,
+                    "url_prefix": self.get_url_prefix(),
                 }
             )
 
@@ -767,7 +767,7 @@ class CRUDAdmin:
                         "events": enriched_events,
                         "page": page,
                         "total_pages": total_pages,
-                        "mount_path": self.mount_path,
+                        "url_prefix": self.get_url_prefix(),
                         "start_date": start_date,
                         "end_date": end_date,
                         "selected_type": event_type,
@@ -785,7 +785,7 @@ class CRUDAdmin:
                         "events": [],
                         "page": 1,
                         "total_pages": 1,
-                        "mount_path": self.mount_path,
+                        "url_prefix": self.get_url_prefix(),
                     },
                 )
 

--- a/crudadmin/admin_interface/model_view.py
+++ b/crudadmin/admin_interface/model_view.py
@@ -692,7 +692,7 @@ class ModelView:
                 "error": error_message,
                 "field_errors": field_errors,
                 "field_values": field_values,
-                "mount_path": self.admin_site.mount_path if self.admin_site else "",
+                "url_prefix": self.get_url_prefix(),
             }
 
             return self.templates.TemplateResponse(
@@ -851,7 +851,7 @@ class ModelView:
                     "current_page": adjusted_page,
                     "rows_per_page": rows_per_page,
                     "primary_key_info": primary_key_info,
-                    "mount_path": self.admin_site.mount_path if self.admin_site else "",
+                    "url_prefix": self.get_url_prefix(),
                 }
 
                 return self.templates.TemplateResponse(
@@ -1002,7 +1002,7 @@ class ModelView:
                 "rows_per_page": rows_per_page,
                 "selected_column": search_column,
                 "primary_key_info": primary_key_info,
-                "mount_path": self.admin_site.mount_path if self.admin_site else "",
+                "url_prefix": self.get_url_prefix(),
                 "sort_column": sort_column,
                 "sort_order": sort_order,
                 "allowed_actions": self.allowed_actions,
@@ -1053,7 +1053,7 @@ class ModelView:
                     "request": request,
                     "model_name": self.model_key,
                     "form_fields": form_fields,
-                    "mount_path": mount_path,
+                    "url_prefix": self.get_url_prefix(),
                 },
             )
 
@@ -1098,14 +1098,13 @@ class ModelView:
                 if field_name in item:
                     field["value"] = item[field_name]
 
-            mount_path = self.admin_site.mount_path if self.admin_site else ""
             return self.templates.TemplateResponse(
                 template,
                 {
                     "request": request,
                     "model_name": self.model_key,
                     "form_fields": form_fields,
-                    "mount_path": mount_path,
+                    "url_prefix": self.get_url_prefix(),
                     "id": id,
                 },
             )
@@ -1267,7 +1266,7 @@ class ModelView:
                 "error": error_message,
                 "field_errors": field_errors,
                 "field_values": field_values,
-                "mount_path": self.admin_site.mount_path if self.admin_site else "",
+                "url_prefix": self.get_url_prefix(),
                 "id": id,
                 "include_sidebar_and_header": False,
             }

--- a/crudadmin/admin_interface/model_view.py
+++ b/crudadmin/admin_interface/model_view.py
@@ -1046,7 +1046,6 @@ class ModelView:
         async def model_create_page(request: Request) -> Response:
             """Show a blank form for creating a new record."""
             form_fields = _get_form_fields_from_schema(self.create_schema)
-            mount_path = self.admin_site.mount_path if self.admin_site else ""
             return self.templates.TemplateResponse(
                 template,
                 {

--- a/crudadmin/templates/admin/dashboard/dashboard.html
+++ b/crudadmin/templates/admin/dashboard/dashboard.html
@@ -5,7 +5,7 @@
 {% set include_sidebar_and_header = True %}
 
 {% block content %}
-    <div id="dynamic-content" hx-get="/{{ mount_path }}/dashboard-content" hx-trigger="load" hx-swap="outerHTML">
+    <div id="dynamic-content" hx-get="{{ url_prefix }}/dashboard-content" hx-trigger="load" hx-swap="outerHTML">
         <div class="loading-state">
             <div class="card">
                 <div class="loading-message">Loading dashboard content...</div>
@@ -22,12 +22,12 @@
         align-items: center;
         min-height: 200px;
     }
-    
+
     .loading-message {
         color: var(--text-secondary-light);
         font-size: 1.1rem;
     }
-    
+
     .dark-theme .loading-message {
         color: var(--text-secondary-dark);
     }

--- a/crudadmin/templates/admin/dashboard/dashboard_content.html
+++ b/crudadmin/templates/admin/dashboard/dashboard_content.html
@@ -97,7 +97,7 @@
         {% if "AdminUser" in auth_table_names %}
             <div class="module">
                 <div class="module-info">
-                    <a href="/{{ mount_path }}/AdminUser" class="module-title">Admin Users</a>
+                    <a href="{{ url_prefix }}/AdminUser" class="module-title">Admin Users</a>
                     <div class="module-stats">
                         <span>Active Users:</span>
                         <span class="stats-badge">{{ auth_model_counts["AdminUser"]|default(0) }}</span>
@@ -109,7 +109,7 @@
         {% if "AdminSession" in auth_table_names %}
             <div class="module">
                 <div class="module-info">
-                    <a href="/{{ mount_path }}/AdminSession" class="module-title">Sessions</a>
+                    <a href="{{ url_prefix }}/AdminSession" class="module-title">Sessions</a>
                     <div class="module-stats">
                         <span>Active Sessions:</span>
                         <span class="stats-badge" title="Total / Active">
@@ -127,7 +127,7 @@
         {% for table_name in table_names %}
             <div class="module">
                 <div class="module-info">
-                    <a href="/{{ mount_path }}/{{ table_name }}" class="module-title">{{ table_name }}</a>
+                    <a href="{{ url_prefix }}/{{ table_name }}" class="module-title">{{ table_name }}</a>
                     <div class="module-stats">
                         <span>Total Records:</span>
                         <span class="stats-badge">{{ model_counts[table_name]|default(0) }}</span>

--- a/crudadmin/templates/admin/management/events.html
+++ b/crudadmin/templates/admin/management/events.html
@@ -288,16 +288,16 @@
         .filter-grid {
             grid-template-columns: 1fr;
         }
-        
+
         .detail-item {
             grid-template-columns: 1fr;
             gap: 0.25rem;
         }
-        
+
         .filter-actions {
             flex-direction: column;
         }
-        
+
         .filter-button {
             width: 100%;
         }
@@ -309,7 +309,7 @@
         <div class="dashboard-header">
             <h1 class="page-title">Event Logs</h1>
         </div>
-        
+
         <div class="filter-section">
             <div class="filter-grid">
                 <div class="filter-group">
@@ -323,7 +323,7 @@
                         {% endfor %}
                     </select>
                 </div>
-                
+
                 <div class="filter-group">
                     <label class="filter-label" for="event-type">Event Type</label>
                     <select id="event-type" name="event_type" class="filter-control">
@@ -350,19 +350,19 @@
 
                 <div class="filter-group">
                     <label class="filter-label" for="start-date">Start Date</label>
-                    <input type="date" 
+                    <input type="date"
                            id="start-date"
-                           name="start_date" 
-                           class="filter-control" 
+                           name="start_date"
+                           class="filter-control"
                            value="{{ start_date }}">
                 </div>
 
                 <div class="filter-group">
                     <label class="filter-label" for="end-date">End Date</label>
-                    <input type="date" 
+                    <input type="date"
                            id="end-date"
-                           name="end_date" 
-                           class="filter-control" 
+                           name="end_date"
+                           class="filter-control"
                            value="{{ end_date }}">
                 </div>
             </div>
@@ -377,8 +377,8 @@
             </div>
         </div>
 
-        <div id="events-content" 
-             hx-get="/{{ mount_path }}/management/events/content"
+        <div id="events-content"
+             hx-get="{{ url_prefix }}/management/events/content"
              hx-trigger="load">
             <div class="event-grid">
                 <div class="event-card">
@@ -405,14 +405,14 @@ function getFilterValues() {
 function applyFilters() {
     const filters = getFilterValues();
     const queryParams = new URLSearchParams();
-    
+
     Object.entries(filters).forEach(([key, value]) => {
         if (value) {
             queryParams.append(key, value);
         }
     });
 
-    const url = `/{{ mount_path }}/management/events/content?${queryParams.toString()}`;
+    const url = `{{ url_prefix }}/management/events/content?${queryParams.toString()}`;
     htmx.ajax('GET', url, {
         target: '#events-content',
         swap: 'innerHTML'

--- a/crudadmin/templates/admin/management/events_content.html
+++ b/crudadmin/templates/admin/management/events_content.html
@@ -8,7 +8,7 @@
                <span class="event-timestamp">{{ event.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</span>
            </div>
        </div>
-       
+
        <div class="event-summary" onclick="toggleDetails(this)">
            <div class="summary-grid">
                <div class="summary-item">
@@ -94,21 +94,21 @@
 
 <div class="pagination">
     <button class="pagination-button"
-            hx-get="/{{ mount_path }}/management/events/content"
+            hx-get="{{ url_prefix }}/management/events/content"
             hx-target="#events-content"
             hx-include="[name='event-type'],[name='status'],[name='start-date'],[name='end-date']"
             hx-vals='js:{"page": "{{ page - 1 }}"}'
             {% if page <= 1 %}disabled{% endif %}>
         Previous
     </button>
-    
+
     <div class="pagination-info">
         Page {{ page }} of {{ total_pages }}
     </div>
-    
+
     <button class="pagination-button"
-            hx-get="/{{ mount_path }}/management/events/content"
-            hx-target="#events-content" 
+            hx-get="{{ url_prefix }}/management/events/content"
+            hx-target="#events-content"
             hx-include="[name='event-type'],[name='status'],[name='start-date'],[name='end-date']"
             hx-vals='js:{"page": "{{ page + 1 }}"}'
             {% if page >= total_pages %}disabled{% endif %}>
@@ -120,7 +120,7 @@
     .event-card {
         margin-bottom: 1rem;
     }
-    
+
     .header-info {
         display: flex;
         align-items: center;

--- a/crudadmin/templates/admin/management/health.html
+++ b/crudadmin/templates/admin/management/health.html
@@ -209,24 +209,24 @@
         <div class="dashboard-header">
             <h1 class="page-title">System Health</h1>
             <button class="refresh-button"
-                    hx-get="/{{ mount_path }}/management/health/content"
+                    hx-get="{{ url_prefix }}/management/health/content"
                     hx-target="#health-content"
                     hx-indicator=".refresh-icon">
                 <svg class="refresh-icon"
-                     fill="none" 
-                     stroke="currentColor" 
+                     fill="none"
+                     stroke="currentColor"
                      viewBox="0 0 24 24">
-                    <path stroke-linecap="round" 
-                          stroke-linejoin="round" 
-                          stroke-width="2" 
+                    <path stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
                           d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                 </svg>
                 Refresh
             </button>
         </div>
-        
-        <div id="health-content" 
-             hx-get="/{{ mount_path }}/management/health/content"
+
+        <div id="health-content"
+             hx-get="{{ url_prefix }}/management/health/content"
              hx-trigger="load delay:100ms">
             <div class="health-grid">
                 <div class="health-card loading-placeholder">

--- a/crudadmin/templates/admin/model/components/list_content.html
+++ b/crudadmin/templates/admin/model/components/list_content.html
@@ -5,7 +5,7 @@
                 <tr>
                     <th class="checkbox-cell">
                         <div class="checkbox-wrapper">
-                            <input type="checkbox" 
+                            <input type="checkbox"
                                    class="custom-checkbox"
                                    name="select-all"
                                    onchange="handleSelectAll(this)">
@@ -17,7 +17,7 @@
                                 {{ header }}
                                 <button class="sort-btn"
                                         title="Toggle sort"
-                                        hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list"
+                                        hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                                         hx-target="#model-list"
                                         hx-include="[name='rows-per-page-select'],[name='column-to-search'],[name='search-input']"
                                         hx-vals='js:{"sort_by": "{{ header }}", "sort_order": "{% if sort_column == header and sort_order == "asc" %}desc{% else %}asc{% endif %}", "page": "1"}'
@@ -48,7 +48,7 @@
                     <tr>
                         <td class="checkbox-cell">
                             <div class="checkbox-wrapper">
-                                <input type="checkbox" 
+                                <input type="checkbox"
                                        class="custom-checkbox"
                                        name="rowSelect"
                                        value="{{ row[primary_key_info.name] }}"

--- a/crudadmin/templates/admin/model/components/pagination.html
+++ b/crudadmin/templates/admin/model/components/pagination.html
@@ -1,8 +1,8 @@
 <div class="pagination-controls">
     <div class="rows-per-page-form">
-        <select name="rows-per-page-select" 
-                hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list" 
-                hx-target="#model-list" 
+        <select name="rows-per-page-select"
+                hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
+                hx-target="#model-list"
                 hx-trigger="change"
                 hx-include="[name='sort_by'],[name='sort_order']">
             <option value="10" {% if rows_per_page == 10 %}selected{% endif %}>10 per page</option>
@@ -13,7 +13,7 @@
     </div>
 
     <div class="pagination-buttons">
-        <button hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list"
+        <button hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                 hx-target="#model-list"
                 hx-include="[name='rows-per-page-select']"
                 hx-vals='js:{"page": "{{ current_page - 1 }}", "sort_by": "{{ sort_column }}", "sort_order": "{{ sort_order }}"}'
@@ -21,7 +21,7 @@
             Previous
         </button>
         <span class="pagination-info">Page {{ current_page }} of {{ (total_items / rows_per_page) | round(0, 'ceil') | int }}</span>
-        <button hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list"
+        <button hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                 hx-target="#model-list"
                 hx-include="[name='rows-per-page-select']"
                 hx-vals='js:{"page": "{{ current_page + 1 }}", "sort_by": "{{ sort_column }}", "sort_order": "{{ sort_order }}"}'

--- a/crudadmin/templates/admin/model/create.html
+++ b/crudadmin/templates/admin/model/create.html
@@ -31,7 +31,7 @@
         .dark-theme .field-error {
             color: #F87171;
         }
-        
+
         .create-form-container .admin-content {
             padding: 2rem;
             max-width: 1400px;
@@ -258,7 +258,7 @@
         </div>
         {% endif %}
 
-        <form method="post" action="/{{ mount_path }}/{{ model_name }}/form_create" enctype="multipart/form-data">
+        <form method="post" action="{{ url_prefix }}/{{ model_name }}/form_create" enctype="multipart/form-data">
             <div class="create-form">
                 <div class="field-section">
                     {% for field in form_fields %}
@@ -281,7 +281,7 @@
                             {% endif %}
                         </div>
                         {% endif %}
-                        
+
                         <!-- Field Input -->
                         {% if field.type == "select" %}
                             <select class="form-control{% if field.name in field_errors %} error{% endif %}"
@@ -296,7 +296,7 @@
                                 </option>
                                 {% endfor %}
                             </select>
-                        
+
                         {% elif field.type == "checkbox" %}
                             <div class="checkbox-wrapper">
                                 <input class="form-control{% if field.name in field_errors %} error{% endif %}"
@@ -308,14 +308,14 @@
                                 <span class="checkbox-label">{{ field.description }}</span>
                                 {% endif %}
                             </div>
-                        
+
                         {% elif field.type == "json" %}
                             <textarea class="form-control{% if field.name in field_errors %} error{% endif %}"
                                 id="{{ field.name }}"
                                 name="{{ field.name }}"
                                 {% if field.required %}required{% endif %}
                                 placeholder="Enter JSON data">{{ field_values[field.name] if field_values and field.name in field_values else '' }}</textarea>
-                        
+
                         {% else %}
                             <input class="form-control{% if field.name in field_errors %} error{% endif %}"
                                 type="{{ field.type }}"
@@ -331,7 +331,7 @@
                                 value="{{ field_values[field.name] if field_values and field.name in field_values else '' }}"
                                 placeholder="{{ field.examples | first | default ('Enter ' + field.title | default(field.name) | capitalize) }}">
                         {% endif %}
-                        
+
                         {% if field.name in field_errors %}
                         <div class="field-error">
                             {{ field_errors[field.name] }}
@@ -349,7 +349,7 @@
 
                 <!-- Form Actions -->
                 <div class="form-actions">
-                    <a href="/{{ mount_path }}/{{ model_name }}/" class="btn btn-secondary">Cancel</a>
+                    <a href="{{ url_prefix }}/{{ model_name }}/" class="btn btn-secondary">Cancel</a>
                     <button type="submit" class="btn btn-primary">Create {{ model_name }}</button>
                 </div>
             </div>

--- a/crudadmin/templates/admin/model/list.html
+++ b/crudadmin/templates/admin/model/list.html
@@ -126,7 +126,7 @@
         font-size: 0.875rem;
     }
 
-    .dark-theme .column-select select, 
+    .dark-theme .column-select select,
     .dark-theme .search-input {
         background: var(--bg-secondary-dark);
         border-color: var(--border-dark);
@@ -351,24 +351,24 @@
         <h1 class="page-title">{{ model_name }} Administration</h1>
         <div class="action-buttons">
             {% if 'create' in allowed_actions %}
-            <a href="/{{ mount_path }}/{{ model_name }}/create" 
+            <a href="{{ url_prefix }}/{{ model_name }}/create"
                class="add-button action-button"
                id="createButton"
-               hx-get="/{{ mount_path }}/{{ model_name }}/create_page" 
+               hx-get="{{ url_prefix }}/{{ model_name }}/create_page"
                hx-target="body">
                 + Add {{ model_name }}
             </a>
             {% endif %}
-            
+
             {% if 'update' in allowed_actions %}
-            <a href="#" 
+            <a href="#"
                class="update-button action-button hidden"
                id="updateButton"
                onclick="handleUpdate()">
                 ✎ Update
             </a>
             {% endif %}
-            
+
             {% if 'delete' in allowed_actions %}
             <button class="delete-button action-button hidden"
                     id="deleteButton"
@@ -383,8 +383,8 @@
     <div class="search-container">
         <div class="search-group">
             <div class="column-select">
-                <select name="column-to-search" 
-                        hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list" 
+                <select name="column-to-search"
+                        hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                         hx-target="#model-list"
                         hx-trigger="change"
                         hx-include="[name='search-input']">
@@ -395,16 +395,16 @@
                     {% endfor %}
                 </select>
             </div>
-            <input type="text" 
+            <input type="text"
                    name="search-input"
                    class="search-input"
                    placeholder="Search..."
-                   hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list"
+                   hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                    hx-target="#model-list"
                    hx-trigger="keyup changed delay:500ms, search"
                    hx-include="[name='column-to-search']">
             <button class="search-button"
-                    hx-get="/{{ mount_path }}/{{ model_name }}/get_model_list"
+                    hx-get="{{ url_prefix }}/{{ model_name }}/get_model_list"
                     hx-target="#model-list"
                     hx-include="[name='column-to-search'],[name='search-input']">
                 Search
@@ -423,7 +423,7 @@
         const createButton = document.getElementById('createButton');
         const updateButton = document.getElementById('updateButton');
         const deleteButton = document.getElementById('deleteButton');
-        
+
         if (checkedBoxes.length === 0) {
             if (createButton) createButton.classList.remove('hidden');
             if (updateButton) updateButton.classList.add('hidden');
@@ -447,12 +447,12 @@
 
     function handleRowSelect() {
         updateActionButtons();
-        
+
         // Update "select all" checkbox
         const allCheckboxes = document.querySelectorAll('input[name="rowSelect"]');
         const checkedBoxes = document.querySelectorAll('input[name="rowSelect"]:checked');
         const selectAllCheckbox = document.querySelector('input[name="select-all"]');
-        
+
         selectAllCheckbox.checked = allCheckboxes.length === checkedBoxes.length;
     }
 
@@ -460,12 +460,12 @@
         if (!type) {
             return value;
         }
-        
+
         // Normalize the type by removing SQL-specific prefixes/suffixes and converting to lowercase
         const baseType = type.toString().toLowerCase()
             .replace(/(sql|types|py|_type|\(.*\))/g, '')
             .trim();
-        
+
         switch(baseType) {
             // Integer types
             case 'int':
@@ -478,7 +478,7 @@
                 }
                 return intValue;
 
-            // Float types    
+            // Float types
             case 'float':
             case 'real':
             case 'double':
@@ -490,7 +490,7 @@
                 }
                 return floatValue;
 
-            // Boolean types    
+            // Boolean types
             case 'bool':
             case 'boolean':
                 if (typeof value === 'boolean') return value;
@@ -500,7 +500,7 @@
                 }
                 return ['true', '1'].includes(strValue);
 
-            // UUID types    
+            // UUID types
             case 'uuid':
                 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
                 if (!uuidRegex.test(value)) {
@@ -516,7 +516,7 @@
             case 'char':
                 return String(value);
 
-            // Default case for unknown types    
+            // Default case for unknown types
             default:
                 return value;
         }
@@ -535,15 +535,15 @@
 
         const modelList = document.getElementById('model-list');
         const pkType = modelList.dataset.pkType;
-        
+
         // Get current page and rows per page
         const paginationInfo = document.querySelector('.pagination-info');
         const currentPageMatch = paginationInfo?.textContent.match(/Page (\d+) of/);
         const currentPage = currentPageMatch ? currentPageMatch[1] : '1';
-        
+
         const rowsPerPageSelect = document.querySelector('[name="rows-per-page-select"]');
         const rowsPerPage = rowsPerPageSelect ? rowsPerPageSelect.value : '10';
-        
+
         // Convert and validate IDs
         const ids = Array.from(checkedBoxes).map(box => {
             const rawValue = box.value.trim();
@@ -561,18 +561,18 @@
         console.log('Sending delete request for IDs:', ids);
 
         try {
-            const response = await fetch(`/{{ mount_path }}/{{ model_name }}/bulk-delete?page=${currentPage}&rows-per-page-select=${rowsPerPage}`, {
+            const response = await fetch(`{{ url_prefix }}/{{ model_name }}/bulk-delete?page=${currentPage}&rows-per-page-select=${rowsPerPage}`, {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ 
+                body: JSON.stringify({
                     ids: ids,
                     page: parseInt(currentPage),
                     rows_per_page: parseInt(rowsPerPage)
                 })
             });
-            
+
             if (!response.ok) {
                 const errorData = await response.json();
                 throw new Error(errorData.detail?.[0]?.msg || 'Error deleting items');
@@ -584,7 +584,7 @@
             htmx.process(tempDiv);
             modelList.replaceWith(tempDiv.firstElementChild);
             updateActionButtons();
-            
+
         } catch (error) {
             alert(error.message || 'Failed to delete items');
         }
@@ -593,7 +593,7 @@
     function handleUpdate() {
         const checkedBox = document.querySelector('input[name="rowSelect"]:checked');
         const id = checkedBox.value;
-        window.location.href = `/{{ mount_path }}/{{ model_name }}/update/${id}`;
+        window.location.href = `{{ url_prefix }}/{{ model_name }}/update/${id}`;
     }
 
     // Initialize event listeners when content is loaded or updated

--- a/crudadmin/templates/admin/model/update.html
+++ b/crudadmin/templates/admin/model/update.html
@@ -31,7 +31,7 @@
         .dark-theme .field-error {
             color: #F87171;
         }
-        
+
         .admin-content {
             padding: 2rem;
             max-width: 1400px;
@@ -271,7 +271,7 @@
         </div>
         {% endif %}
 
-        <form method="post" action="/{{ mount_path }}/{{ model_name }}/form_update/{{ id }}" enctype="multipart/form-data">
+        <form method="post" action="{{ url_prefix }}/{{ model_name }}/form_update/{{ id }}" enctype="multipart/form-data">
             <div class="field-section">
                 {% for field in form_fields %}
                 <div class="form-group">
@@ -363,7 +363,7 @@
 
             <!-- Form Actions -->
             <div class="form-actions">
-                <a href="/{{ mount_path }}/{{ model_name }}/" class="btn btn-secondary">Cancel</a>
+                <a href="{{ url_prefix }}/{{ model_name }}/" class="btn btn-secondary">Cancel</a>
                 <button type="submit" class="btn btn-primary">Update {{ model_name }}</button>
             </div>
         </form>

--- a/crudadmin/templates/auth/login.html
+++ b/crudadmin/templates/auth/login.html
@@ -124,12 +124,12 @@
 
 <div class="login-container">
     <div class="login-header">
-        <img src="{% if mount_path %}/{{ mount_path }}{% endif %}/static/favicon.png" alt="FastAPI Admin" class="login-header-icon">
+        <img src="{{ url_prefix }}/static/favicon.png" alt="FastAPI Admin" class="login-header-icon">
         FastAPI Administration
     </div>
-    
-    <form class="login-form" 
-          action="{% if mount_path %}/{{ mount_path }}{% endif %}/login" 
+
+    <form class="login-form"
+          action="{{ url_prefix }}/login"
           method="post"
           enctype="application/x-www-form-urlencoded">
         {% if error %}
@@ -137,22 +137,22 @@
             {{ error }}
         </div>
         {% endif %}
-        
+
         <div class="form-group">
             <label class="form-label" for="username">Username</label>
             <input type="text" id="username" name="username" class="form-control" required>
         </div>
-        
+
         <div class="form-group">
             <label class="form-label" for="password">Password</label>
             <input type="password" id="password" name="password" class="form-control" required>
         </div>
-        
+
         <input type="hidden" name="grant_type" value="password">
         <input type="hidden" name="scope" value="">
         <input type="hidden" name="client_id" value="">
         <input type="hidden" name="client_secret" value="">
-        
+
         <button type="submit" class="login-btn">Log in</button>
     </form>
 </div>

--- a/crudadmin/templates/base/base.html
+++ b/crudadmin/templates/base/base.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}FastAPI Admin{% endblock %}</title>
-    <link rel="icon" type="image/png" href="{% if mount_path %}/{{ mount_path }}{% endif %}/static/favicon.png?v=1">
+    <link rel="icon" type="image/png" href="{{ url_prefix }}/static/favicon.png?v=1">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <script src="{% if mount_path %}/{{ mount_path }}{% endif %}/static/htmx.min.js"></script>
+    <script src="{{ url_prefix }}/static/htmx.min.js"></script>
     <style>
         /* Modern CSS Reset */
         *, *::before, *::after {
@@ -22,31 +22,31 @@
             --primary-dark: #00796B;
             --primary-light: #B2DFDB;
             --accent-color: #607D8B;
-            
+
             /* Light Theme */
             --bg-primary-light: #ffffff;
             --bg-secondary-light: #f7f7f7;
             --text-primary-light: #333333;
             --text-secondary-light: #666666;
             --border-light: #e0e0e0;
-            
+
             /* Dark Theme */
             --bg-primary-dark: #1e2129;
             --bg-secondary-dark: #282c34;
             --text-primary-dark: #ffffff;
             --text-secondary-dark: #b0b0b0;
             --border-dark: #3a3f4c;
-            
+
             /* Status Colors */
             --success-color: #4CAF50;
             --danger-color: #f44336;
             --warning-color: #ff9800;
-            
+
             /* Layout */
             --header-height: 64px;
             --sidebar-width: 260px;
             --content-max-width: 1200px;
-            
+
             /* Components */
             --border-radius-sm: 4px;
             --border-radius-md: 8px;
@@ -274,21 +274,21 @@
 </head>
 <body class="{{ theme|default('dark-theme', true) }}">
     {% set include_sidebar_and_header = include_sidebar_and_header | default(false) %}
-    
+
     <div class="{% if include_sidebar_and_header %}admin-container{% endif %}">
         {% if include_sidebar_and_header %}
             <header class="admin-header">
-                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/" class="brand">
-                    <img src="{% if mount_path %}/{{ mount_path }}{% endif %}/static/favicon.png" alt="FastAPI Admin" class="brand-icon">
+                <a href="{{ url_prefix }}/" class="brand">
+                    <img src="{{ url_prefix }}/static/favicon.png" alt="FastAPI Admin" class="brand-icon">
                     FastAPI Admin
                 </a>
                 <div class="flex items-center gap-4">
-                    <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/logout" style="color: white; text-decoration: none; font-weight: 500; transition: color 0.2s" onmouseover="this.style.color='var(--primary-light)'" onmouseout="this.style.color='white'">
+                    <a href="{{ url_prefix }}/logout" style="color: white; text-decoration: none; font-weight: 500; transition: color 0.2s" onmouseover="this.style.color='var(--primary-light)'" onmouseout="this.style.color='white'">
                         Logout
                     </a>
                 </div>
             </header>
-            
+
             <aside class="admin-sidebar">
                 <nav>
                     <!-- Dashboard Section -->
@@ -299,7 +299,7 @@
                         </div>
                         <ul class="sidebar-nav">
                             <li>
-                                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/" class="sidebar-link active">
+                                <a href="{{ url_prefix }}/" class="sidebar-link active">
                                     Dashboard
                                 </a>
                             </li>
@@ -314,14 +314,14 @@
                         </div>
                         <ul class="sidebar-nav">
                             <li>
-                                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/management/health" class="sidebar-link">
+                                <a href="{{ url_prefix }}/management/health" class="sidebar-link">
                                     Health Checks
                                     <span class="badge badge-primary">System</span>
                                 </a>
                             </li>
                             {% if track_events %}
                             <li>
-                                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/management/events" class="sidebar-link">
+                                <a href="{{ url_prefix }}/management/events" class="sidebar-link">
                                     Event Logs
                                     <span class="badge badge-primary">System</span>
                                 </a>
@@ -339,7 +339,7 @@
                         <ul class="sidebar-nav">
                             {% for auth_table_name in auth_table_names %}
                             <li>
-                                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/{{ auth_table_name }}/" class="sidebar-link">
+                                <a href="{{ url_prefix }}/{{ auth_table_name }}/" class="sidebar-link">
                                     {{ auth_table_name }}
                                     <span class="model-count">{{ auth_model_counts[auth_table_name]|default(0) }}</span>
                                 </a>
@@ -358,7 +358,7 @@
                         <ul class="sidebar-nav">
                             {% for table_name in table_names %}
                             <li>
-                                <a href="{% if mount_path %}/{{ mount_path }}{% endif %}/{{ table_name }}/" class="sidebar-link">
+                                <a href="{{ url_prefix }}/{{ table_name }}/" class="sidebar-link">
                                     {{ table_name }}
                                     <span class="model-count">{{ model_counts[table_name]|default(0) }}</span>
                                 </a>
@@ -370,7 +370,7 @@
                 </nav>
             </aside>
         {% endif %}
-        
+
         <main class="admin-main">
             {% block content %}{% endblock %}
         </main>
@@ -380,7 +380,7 @@
         function initializeSidebar() {
             const currentPath = window.location.pathname;
             const sidebarLinks = document.querySelectorAll('.sidebar-link');
-            
+
             sidebarLinks.forEach(link => {
                 if (link.getAttribute('href') === currentPath) {
                     link.classList.add('active');
@@ -394,12 +394,12 @@
             document.querySelectorAll('.sidebar-section-header').forEach(header => {
                 const section = header.parentElement;
                 const sectionId = header.querySelector('.sidebar-section-title').textContent;
-                
+
                 // Restore state from localStorage
                 if (localStorage.getItem(`sidebar-${sectionId}`) === 'collapsed') {
                     section.classList.add('collapsed');
                 }
-                
+
                 // Update localStorage on toggle
                 header.addEventListener('click', () => {
                     const isCollapsed = section.classList.contains('collapsed');


### PR DESCRIPTION
## 🐛 Problem

When mounting the admin panel at the root path (`mount_path="/"`), dashboard content fails to load. The issue comes from templates building URLs like:

```jinja2
<a href="/{{ mount_path }}/...">
```

With an empty `mount_path`, this results in `//dashboard-content`, which doesn’t match any registered FastAPI route.

## ✅ Solution

To fix this, I introduced a `url_prefix` variable in the Python context that normalizes the mount path with a leading slash only when necessary:

```python
self.url_prefix = f"/{self.mount_path}" if self.mount_path else ""
```

All template links now use `{{ url_prefix }}` instead of building paths manually:

```jinja2
<a href="{{ url_prefix }}/">Link</a>
```

This ensures routes work whether the panel is mounted at `/`, `/admin`, or any subpath.

## 🧪 Testing

- `mount_path="/"` → dashboard loads ✅
- `mount_path="/admin"` → still works as before ✅
- Verified dashboard content, navigation links, HTMX loading

## 📹 Before Fix
https://github.com/user-attachments/assets/4c026c69-0b88-449f-8f52-2001e38817da
