### PR TITLE
Adding Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.1
+    hooks:
+      - id: ruff
+        args: ["check", "crudadmin", "--fix"]
+      - id: ruff-format
+        args: ["crudadmin"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.1
+    hooks:
+      - id: mypy
+        args: ["crudadmin", "--strict"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,31 @@ CRUDAdmin uses pytest for testing. Run tests using:
 uv run pytest
 ```
 
+### Pre-commit Hooks
+CRUDAdmin uses pre-commit to automatically check code quality before each commit. It helps enforce
+linting, formatting, and type checking.
+
+After installing the development dependencies:
+
+```sh
+uv run pre-commit install
+```
+
+This will set up thee Git hooks to run automatically before every commit.
+
+*Running hooks Manually*
+To run all hooks on all files:
+```sh
+uv run pre-commit run --all-files
+```
+
+This will run:
+- `ruff` fot linting and formatting
+- `mypy` for type checking
+- basic formatting checks (trailing whitespace, EOF, file size)
+
+Make sure all pre-commit checks pass before submitting a PR.
+
 ### Linting
 Use mypy for type checking:
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,8 @@ dev = [
     "httptools>=0.6.4",
     "httpx>=0.28.1",
     "sqlalchemy[mypy]>=2.0.36",
-    "sqlalchemy-utils>=0.41.2"
+    "sqlalchemy-utils>=0.41.2",
+    "pre-commit>=3.5.0"
 ]
 
 docs = [


### PR DESCRIPTION
# Pre-commit Hooks

Hi, everyone!

This PR introduces pre-commit support to improve code quality and consistency by:

- Adding `.pre-commit-config.yaml` with hooks for:
  - trailing whitespace removal, end-of-file fixer, and large file checks
  - `ruff` for linting and formatting
  - `mypy` for static type checking

- Adding `pre-commit` as a development dependency in `pyproject.toml`

- Updating `CONTRIBUTING.md` with instructions on how to install and use pre-commit hooks

Automating these checks helps maintain a cleaner codebase, reduces manual errors, and enforces the project's coding standards before commits are made.

### Testing

- Verified local installation of pre-commit hooks
- Ran hooks manually and verified fixes and type checking
- Ensured all existing tests pass after changes

### Example of using
![image](https://github.com/user-attachments/assets/4a9a7753-b61e-4241-8682-f2d7d0d32cce)

