### PR TITLE
Adjust responsive limits in authentication layout

### DIFF
--- a/crudadmin/templates/base/base.html
+++ b/crudadmin/templates/base/base.html
@@ -269,6 +269,12 @@
             color: var(--primary-light);
         }
 
+        .admin-main {
+            grid-column: 2;
+            padding: 0.5rem;
+            overflow-x: auto;
+        }
+
     </style>
     {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
### Changes
Hey! I noticed that there was a slight excess in the authentication screens that made the screen much larger and disproportionate to the screen.

I looked at the way base.html sets up the css style and realized that this could be solved by adding some css rules to it. This makes the screens proportional to the canvas. I've left some images with the results. Let me know if you agree with this implementation :)

### Before
<img width="2452" height="1288" alt="image" src="https://github.com/user-attachments/assets/a19a0e16-e83c-4b3a-ac13-b4d3ee0e40cb" />

### After
<img width="2444" height="1274" alt="image" src="https://github.com/user-attachments/assets/15afd0d1-f432-4d59-a538-ef2aaed111da" />
