### PR TITLE
Fix/admin issues

### DIFF
--- a/crudadmin/admin_interface/crud_admin.py
+++ b/crudadmin/admin_interface/crud_admin.py
@@ -1287,7 +1287,7 @@ class CRUDAdmin:
                         if isinstance(admin_data, AdminUserCreate):
                             create_data = admin_data
                         else:
-                            create_data = AdminUserCreate(**admin_data.dict())
+                            create_data = AdminUserCreate(**admin_data.model_dump())
                     else:
                         msg = (
                             "Initial admin data must be either a dict or Pydantic model"

--- a/crudadmin/admin_interface/helper.py
+++ b/crudadmin/admin_interface/helper.py
@@ -85,7 +85,7 @@ def _get_form_fields_from_schema(schema: Type[BaseModel]) -> List[FormField]:
     """
     form_fields: List[FormField] = []
 
-    fields_dict = cast(Dict[str, Any], schema.__fields__)
+    fields_dict = cast(Dict[str, Any], schema.model_fields)
 
     for field_name, field_info in fields_dict.items():
         field_type = field_info.annotation

--- a/crudadmin/admin_interface/model_view.py
+++ b/crudadmin/admin_interface/model_view.py
@@ -25,13 +25,18 @@ from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 
-from ..core.db import DatabaseConfig, convert_id_to_pk_type
+from ..core.db import (
+    DatabaseConfig,
+    convert_id_to_pk_type,
+    get_primary_key_name,
+)
 from ..event import EventType, log_admin_action
 from .helper import _get_form_fields_from_schema
 from .relationships import (
     RelationshipInfo,
     RelationshipType,
     detect_relationships,
+    load_relationship_options,
     resolve_display_field,
 )
 
@@ -382,6 +387,7 @@ class ModelView:
         self.templates = templates
         self.model = model
         self.model_key = model.__name__
+        self.primary_key_name = get_primary_key_name(model)
         self.router = APIRouter()
         self.admin_model = admin_model
         self.admin_site = admin_site
@@ -457,6 +463,14 @@ class ModelView:
 
         return convert_id_to_pk_type(id_value, self.db_config, self.model)
 
+    def _pk_filter(self, pk_value: Any) -> Dict[str, Any]:
+        """Build the primary-key filter kwargs for FastCRUD get/update calls.
+
+        Uses the model's actual primary-key column name so models whose key is
+        not ``id`` work correctly.
+        """
+        return {self.primary_key_name: pk_value}
+
     def _with_resolved_display_field(
         self, relationship: RelationshipInfo
     ) -> RelationshipInfo:
@@ -476,6 +490,33 @@ class ModelView:
         if display_field == relationship.display_field:
             return relationship
         return replace(relationship, display_field=display_field)
+
+    async def _apply_relationship_form_fields(
+        self, form_fields: List[Dict[str, Any]], db: AsyncSession
+    ) -> None:
+        """Turn foreign-key form fields into relationship dropdowns.
+
+        For each ``BelongsTo`` relationship, the form field matching its foreign
+        key column is marked as a ``relationship_select`` and populated with the
+        related records (label resolved via the related model's ``display_field``)
+        so the user picks from existing rows instead of typing a raw id.
+        """
+        fk_relationships = {
+            rel.foreign_key: rel
+            for rel in self.relationships.values()
+            if rel.relationship_type == RelationshipType.BELONGS_TO and rel.foreign_key
+        }
+        if not fk_relationships:
+            return
+
+        for field in form_fields:
+            relationship = fk_relationships.get(field["name"])
+            if relationship is None:
+                continue
+            resolved = self._with_resolved_display_field(relationship)
+            field["type"] = "relationship_select"
+            field["related_model_name"] = resolved.related_model_name
+            field["options"] = await load_relationship_options(db, resolved)
 
     def setup_routes(self) -> None:
         """
@@ -732,6 +773,7 @@ class ModelView:
                             request.state.crud_result = result
                             model_list_url = (
                                 f"{self.get_url_prefix()}/{self.model.__name__}/"
+                                "?success=created"
                             )
                             if "HX-Request" in request.headers:
                                 return RedirectResponse(
@@ -749,10 +791,13 @@ class ModelView:
                         }
                         error_message = "Please correct the errors below."
                     except Exception as e:
+                        await db.rollback()
                         error_message = str(e)
 
             except Exception as e:
                 error_message = str(e)
+
+            await self._apply_relationship_form_fields(form_fields, db)
 
             context = {
                 "model_name": self.model_key,
@@ -1075,6 +1120,15 @@ class ModelView:
                 table_columns = [column.key for column in self.model.__table__.columns]
             primary_key_info = self.db_config.get_primary_key_info(self.model)
 
+            success_messages = {
+                "created": f"{self.model_key} created successfully.",
+                "updated": f"{self.model_key} updated successfully.",
+                "deleted": f"{self.model_key} deleted successfully.",
+            }
+            success_message = success_messages.get(
+                request.query_params.get("success", "")
+            )
+
             context: Dict[str, Any] = {
                 "model_items": items["data"],
                 "model_name": self.model_key,
@@ -1089,6 +1143,7 @@ class ModelView:
                 "sort_order": sort_order,
                 "allowed_actions": self.allowed_actions,
                 "relationships": self.relationships,
+                "success_message": success_message,
             }
 
             if "HX-Request" in request.headers:
@@ -1130,9 +1185,13 @@ class ModelView:
             ```
         """
 
-        async def model_create_page(request: Request) -> Response:
+        async def model_create_page(
+            request: Request,
+            db: AsyncSession = Depends(self.session),
+        ) -> Response:
             """Show a blank form for creating a new record."""
             form_fields = _get_form_fields_from_schema(self.create_schema)
+            await self._apply_relationship_form_fields(form_fields, db)
             return self.templates.TemplateResponse(
                 name=template,
                 request=request,
@@ -1171,7 +1230,9 @@ class ModelView:
             converted_id = self._convert_id_to_pk_type(id)
 
             item = await self.crud.get(
-                db=db, id=converted_id, schema_to_select=self.select_schema
+                db=db,
+                schema_to_select=self.select_schema,
+                **self._pk_filter(converted_id),
             )
             if not item:
                 return JSONResponse(
@@ -1179,6 +1240,7 @@ class ModelView:
                 )
 
             form_fields = _get_form_fields_from_schema(self.update_schema)
+            await self._apply_relationship_form_fields(form_fields, db)
             field_values: Dict[str, Any] = {}
             for field in form_fields:
                 field_name = field["name"]
@@ -1236,7 +1298,9 @@ class ModelView:
             converted_id = self._convert_id_to_pk_type(id)
 
             item = await self.crud.get(
-                db=db, id=converted_id, schema_to_select=self.select_schema
+                db=db,
+                schema_to_select=self.select_schema,
+                **self._pk_filter(converted_id),
             )
             if not item:
                 return JSONResponse(
@@ -1290,10 +1354,10 @@ class ModelView:
                     error_message = "No changes were provided for update"
                 else:
                     if self.update_internal_schema is not None and hasattr(
-                        self.update_internal_schema, "__fields__"
+                        self.update_internal_schema, "model_fields"
                     ):
                         fields_dict = cast(
-                            Dict[str, Any], self.update_internal_schema.__fields__
+                            Dict[str, Any], self.update_internal_schema.model_fields
                         )
                         if "updated_at" in fields_dict:
                             update_data["updated_at"] = dt.now(datetime.UTC)
@@ -1315,7 +1379,9 @@ class ModelView:
                                     AdminUserUpdateInternal(**transformed_data)
                                 )
                                 await self.crud.update(
-                                    db=db, id=converted_id, object=admin_update_schema
+                                    db=db,
+                                    object=admin_update_schema,
+                                    **self._pk_filter(converted_id),
                                 )
                             else:
                                 if self.update_internal_schema:
@@ -1324,8 +1390,8 @@ class ModelView:
                                     )
                                     await self.crud.update(
                                         db=db,
-                                        id=converted_id,
                                         object=generic_update_schema,
+                                        **self._pk_filter(converted_id),
                                     )
                                 else:
                                     dynamic_update_schema = type(
@@ -1333,20 +1399,23 @@ class ModelView:
                                     )(**transformed_data)
                                     await self.crud.update(
                                         db=db,
-                                        id=converted_id,
                                         object=dynamic_update_schema,
+                                        **self._pk_filter(converted_id),
                                     )
 
                             await db.commit()
                         else:
                             update_schema_instance = self.update_schema(**update_data)
                             await self.crud.update(
-                                db=db, id=converted_id, object=update_schema_instance
+                                db=db,
+                                object=update_schema_instance,
+                                **self._pk_filter(converted_id),
                             )
                             await db.commit()
 
                         model_list_url = (
                             f"{self.get_url_prefix()}/{self.model.__name__}/"
+                            "?success=updated"
                         )
                         return RedirectResponse(
                             url=model_list_url,
@@ -1359,6 +1428,7 @@ class ModelView:
                         }
                         error_message = "Please correct the errors below."
                     except Exception as e:
+                        await db.rollback()
                         error_message = str(e)
 
             except Exception as e:
@@ -1368,6 +1438,8 @@ class ModelView:
                 field_name = field["name"]
                 if field_name not in field_values and field_name in item:
                     field_values[field_name] = item[field_name]
+
+            await self._apply_relationship_form_fields(form_fields, db)
 
             context: Dict[str, Any] = {
                 "model_name": self.model_key,

--- a/crudadmin/core/db.py
+++ b/crudadmin/core/db.py
@@ -16,7 +16,12 @@ from uuid import UUID
 from fastcrud import FastCRUD
 from pydantic import BaseModel
 from sqlalchemy import Table, inspect
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase
 
 if TYPE_CHECKING:
@@ -42,6 +47,24 @@ def get_default_db_path() -> str:
     data_dir = os.path.join(cwd, "crudadmin_data")
     os.makedirs(data_dir, exist_ok=True)
     return os.path.join(data_dir, "admin.db")
+
+
+def get_primary_key_name(model: Type[DeclarativeBase]) -> str:
+    """Return the name of the model's first primary key column.
+
+    Used as the filter key for FastCRUD lookups so models whose primary key is
+    not named ``id`` (e.g. ``job_id``) work in get/update/delete operations.
+
+    Raises:
+        ValueError: If the model has no primary key.
+    """
+    primary_key_columns = inspect(model).primary_key
+    if not primary_key_columns:
+        raise ValueError(
+            f"Model {model.__name__} has no primary key; CRUDAdmin requires "
+            "a primary key to manage a model."
+        )
+    return str(primary_key_columns[0].name)
 
 
 def convert_id_to_pk_type(
@@ -128,10 +151,18 @@ class DatabaseConfig:
         self.admin_session: AsyncSession = AsyncSession(
             self.admin_engine, expire_on_commit=False
         )
+        self.admin_session_maker: async_sessionmaker[AsyncSession] = async_sessionmaker(
+            self.admin_engine, expire_on_commit=False
+        )
 
         async def get_admin_db() -> AsyncGenerator[AsyncSession, None]:
-            yield self.admin_session
-            await self.admin_session.commit()
+            async with self.admin_session_maker() as session:
+                try:
+                    yield session
+                    await session.commit()
+                except Exception:
+                    await session.rollback()
+                    raise
 
         self.get_admin_db: Callable[[], AsyncGenerator[AsyncSession, None]] = (
             get_admin_db

--- a/crudadmin/event/decorators.py
+++ b/crudadmin/event/decorators.py
@@ -9,7 +9,11 @@ from fastcrud import FastCRUD
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 
-from crudadmin.core.db import DatabaseConfig, convert_id_to_pk_type
+from crudadmin.core.db import (
+    DatabaseConfig,
+    convert_id_to_pk_type,
+    get_primary_key_name,
+)
 
 from .models import EventType
 
@@ -49,9 +53,12 @@ def convert_user_to_dict(user: Any) -> Dict[str, Any]:
     """Convert user object to dictionary, handling both dict and Pydantic-like objects."""
     if isinstance(user, dict):
         return user
-    elif hasattr(user, "dict"):
-        user_dict: dict = user.dict()
+    elif hasattr(user, "model_dump"):
+        user_dict: dict = user.model_dump()
         return user_dict
+    elif hasattr(user, "dict"):
+        legacy_dict: dict = user.dict()
+        return legacy_dict
     elif hasattr(user, "__dict__"):
         return {k: v for k, v in user.__dict__.items() if not k.startswith("_")}
     else:
@@ -92,13 +99,15 @@ def log_admin_action(
 
                     if "id" in kwargs:
                         assert crud is not None, "CRUD instance should be initialized."
+                        assert model is not None
                         request_id = kwargs["id"]
                         if db_config:
                             request_id = convert_id_to_pk_type(
                                 request_id, db_config, model
                             )
 
-                        item = await crud.get(db=db, id=request_id)
+                        pk_name = get_primary_key_name(model)
+                        item = await crud.get(db=db, **{pk_name: request_id})
                         if item:
                             previous_state = {
                                 k: v for k, v in item.items() if not k.startswith("_")
@@ -130,7 +139,16 @@ def log_admin_action(
                             assert crud is not None, (
                                 "CRUD instance should be initialized."
                             )
-                            updated_item = await crud.get(db=db, id=kwargs["id"])
+                            assert model is not None
+                            request_id = kwargs["id"]
+                            if db_config:
+                                request_id = convert_id_to_pk_type(
+                                    request_id, db_config, model
+                                )
+                            pk_name = get_primary_key_name(model)
+                            updated_item = await crud.get(
+                                db=db, **{pk_name: request_id}
+                            )
                             if updated_item:
                                 new_state = {
                                     k: v

--- a/crudadmin/templates/admin/model/create.html
+++ b/crudadmin/templates/admin/model/create.html
@@ -302,7 +302,21 @@
                         {% endif %}
 
                         <!-- Field Input -->
-                        {% if field.type == "select" %}
+                        {% if field.type == "relationship_select" %}
+                            <select class="form-control{% if field.name in field_errors %} error{% endif %}"
+                                id="{{ field.name }}"
+                                name="{{ field.name }}"
+                                {% if field.required %}required{% endif %}>
+                                <option value="">Select {{ field.related_model_name }}</option>
+                                {% for option in field.options %}
+                                <option value="{{ option.id }}"
+                                    {% if field_values and field_values[field.name] is not none and field_values[field.name] | string == option.id | string %}selected{% endif %}>
+                                    {{ option.display_name }}
+                                </option>
+                                {% endfor %}
+                            </select>
+
+                        {% elif field.type == "select" %}
                             <select class="form-control{% if field.name in field_errors %} error{% endif %}"
                                 id="{{ field.name }}"
                                 name="{{ field.name }}"

--- a/crudadmin/templates/admin/model/list.html
+++ b/crudadmin/templates/admin/model/list.html
@@ -12,6 +12,45 @@
         margin: 0 auto;
     }
 
+    .success-banner {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 1.25rem;
+        padding: 0.75rem 1rem;
+        border-radius: var(--border-radius, 6px);
+        background: rgba(34, 197, 94, 0.12);
+        border: 1px solid rgba(34, 197, 94, 0.4);
+        color: #15803d;
+    }
+
+    .dark-theme .success-banner {
+        background: rgba(34, 197, 94, 0.15);
+        color: #4ade80;
+    }
+
+    .success-banner-icon {
+        font-weight: 700;
+    }
+
+    .success-banner-text {
+        flex: 1;
+    }
+
+    .success-banner-close {
+        background: none;
+        border: none;
+        font-size: 1.25rem;
+        line-height: 1;
+        cursor: pointer;
+        color: inherit;
+        opacity: 0.7;
+    }
+
+    .success-banner-close:hover {
+        opacity: 1;
+    }
+
     .page-header {
         margin-bottom: 2rem;
         display: flex;
@@ -347,6 +386,27 @@
 
 {% block content %}
 <div class="admin-content">
+    {% if success_message %}
+    <div class="success-banner" id="successBanner" role="status">
+        <span class="success-banner-icon">✓</span>
+        <span class="success-banner-text">{{ success_message }}</span>
+        <button type="button" class="success-banner-close"
+                onclick="document.getElementById('successBanner').remove()"
+                aria-label="Dismiss">&times;</button>
+    </div>
+    <script>
+        // Auto-dismiss and strip the ?success param so a refresh doesn't re-show it.
+        setTimeout(function () {
+            var b = document.getElementById('successBanner');
+            if (b) b.remove();
+        }, 4000);
+        if (window.history.replaceState) {
+            var url = new URL(window.location);
+            url.searchParams.delete('success');
+            window.history.replaceState({}, '', url);
+        }
+    </script>
+    {% endif %}
     <div class="page-header">
         <h1 class="page-title">{{ model_name }} Administration</h1>
         <div class="action-buttons">

--- a/crudadmin/templates/admin/model/update.html
+++ b/crudadmin/templates/admin/model/update.html
@@ -314,7 +314,21 @@
                     {% endif %}
 
                     <!-- Field Input Logic -->
-                    {% if field.type == "select" %}
+                    {% if field.type == "relationship_select" %}
+                        <select class="form-control{% if field.name in field_errors %} error{% endif %}"
+                            id="{{ field.name }}"
+                            name="{{ field.name }}"
+                            {% if field.required %}required{% endif %}>
+                            <option value="">Select {{ field.related_model_name }}</option>
+                            {% for option in field.options %}
+                            <option value="{{ option.id }}"
+                                {% if field_values and field_values[field.name] is not none and field_values[field.name] | string == option.id | string %}selected{% endif %}>
+                                {{ option.display_name }}
+                            </option>
+                            {% endfor %}
+                        </select>
+
+                    {% elif field.type == "select" %}
                         <select class="form-control{% if field.name in field_errors %} error{% endif %}"
                             id="{{ field.name }}"
                             name="{{ field.name }}"

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -4,6 +4,7 @@ from typing import Type
 
 import pytest
 import sqlalchemy.exc
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 
@@ -246,3 +247,28 @@ async def test_database_config_cleanup(async_session):
 
         if os.path.exists(admin_db_path):
             os.unlink(admin_db_path)
+
+
+@pytest.mark.asyncio
+async def test_get_admin_db_yields_fresh_session_per_request(db_config):
+    """Each get_admin_db() call yields its own session (not a shared singleton)."""
+    sessions = []
+    async for session in db_config.get_admin_db():
+        sessions.append(session)
+    async for session in db_config.get_admin_db():
+        sessions.append(session)
+
+    assert sessions[0] is not sessions[1]
+
+
+@pytest.mark.asyncio
+async def test_get_admin_db_recovers_after_error(db_config):
+    """A failed statement in one request must not poison later requests (#65)."""
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        async for session in db_config.get_admin_db():
+            await session.execute(text("SELECT * FROM table_that_does_not_exist"))
+
+    # A subsequent request gets a clean, usable session.
+    async for session in db_config.get_admin_db():
+        result = await session.execute(text("SELECT 1"))
+        assert result.scalar() == 1

--- a/tests/crud/test_non_id_primary_key.py
+++ b/tests/crud/test_non_id_primary_key.py
@@ -1,0 +1,86 @@
+"""Tests for models whose primary key is not named ``id`` (issue #68).
+
+CRUDAdmin must use the model's actual primary-key column name as the filter
+key for get/update/delete, instead of hardcoding ``id``.
+"""
+
+import pytest
+from fastcrud import FastCRUD
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.exc import NoInspectionAvailable
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from crudadmin.core.db import get_primary_key_name
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class DeploymentJob(Base):
+    __tablename__ = "deployment_jobs"
+
+    job_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255))
+
+
+class JobCreate(BaseModel):
+    name: str
+
+
+class JobUpdate(BaseModel):
+    name: str
+
+
+def test_get_primary_key_name_non_id():
+    assert get_primary_key_name(DeploymentJob) == "job_id"
+
+
+def test_get_primary_key_name_rejects_non_model():
+    """A non-mapped class raises rather than silently returning ``"id"``."""
+
+    class NotAModel:
+        pass
+
+    with pytest.raises(NoInspectionAvailable):
+        get_primary_key_name(NotAModel)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_update_delete_with_non_id_pk():
+    """get/update/delete keyed on the real PK column works end to end.
+
+    This mirrors what ModelView now does (filter by ``get_primary_key_name``
+    instead of ``id``). Before the fix, ``id=`` was hardcoded and Postgres /
+    fastcrud rejected it with "Invalid column 'id'".
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    crud: FastCRUD = FastCRUD(DeploymentJob)
+    pk_name = get_primary_key_name(DeploymentJob)
+
+    async with AsyncSession(engine) as db:
+        await crud.create(db=db, object=JobCreate(name="build"))
+        await db.commit()
+
+        # get by the real PK column
+        job = await crud.get(db=db, **{pk_name: 1})
+        assert job is not None
+        assert job["name"] == "build"
+
+        # update by the real PK column
+        await crud.update(db=db, object=JobUpdate(name="deploy"), **{pk_name: 1})
+        await db.commit()
+        job = await crud.get(db=db, **{pk_name: 1})
+        assert job["name"] == "deploy"
+
+        # delete by the real PK column
+        await crud.delete(db=db, allow_multiple=False, **{pk_name: 1})
+        await db.commit()
+        assert await crud.get(db=db, **{pk_name: 1}) is None
+
+    await engine.dispose()

--- a/tests/event/test_decorators.py
+++ b/tests/event/test_decorators.py
@@ -289,6 +289,7 @@ class TestConvertUserToDict:
         user = MagicMock()
         user.id = 1
         user.username = "testuser"
+        del user.model_dump  # Remove pydantic v2 dump method if exists
         del user.dict  # Remove dict method if exists
         del user.__dict__  # Remove __dict__ attribute if exists
 
@@ -352,7 +353,7 @@ class TestLogAdminActionDecorator:
         """Test log_admin_action decorator with UPDATE event."""
         user = {"id": 1, "username": "testuser"}
 
-        @log_admin_action(EventType.UPDATE, MockModel)
+        @log_admin_action(EventType.UPDATE, MockIntModel)
         async def test_function(request, db, admin_db, current_user, id, **kwargs):
             return {"id": id, "name": "updated_item"}
 
@@ -387,7 +388,7 @@ class TestLogAdminActionDecorator:
         """Test log_admin_action decorator with DELETE event."""
         user = {"id": 1, "username": "testuser"}
 
-        @log_admin_action(EventType.DELETE, MockModel)
+        @log_admin_action(EventType.DELETE, MockIntModel)
         async def test_function(request, db, admin_db, current_user, **kwargs):
             return {"message": "deleted"}
 

--- a/tests/relationships/test_relationship_form_fields.py
+++ b/tests/relationships/test_relationship_form_fields.py
@@ -1,0 +1,147 @@
+"""Foreign-key form fields render as relationship dropdowns (issue #53)."""
+
+from unittest.mock import Mock
+
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, relationship
+
+from crudadmin.admin_interface.helper import _get_form_fields_from_schema
+from crudadmin.admin_interface.model_view import ModelView
+from crudadmin.core.db import DatabaseConfig
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Author(Base):
+    __tablename__ = "fkf_authors"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    books = relationship("Book", back_populates="author")
+
+
+class Book(Base):
+    __tablename__ = "fkf_books"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    author_id = Column(Integer, ForeignKey("fkf_authors.id"))
+    author = relationship("Author", back_populates="books")
+
+
+class BookCreate(BaseModel):
+    title: str
+    author_id: int
+
+
+class BookUpdate(BaseModel):
+    title: str
+    author_id: int
+
+
+def _fresh_admin_base() -> type:
+    """A unique admin base per DatabaseConfig to avoid table-redefinition clashes."""
+
+    class AdminBase(DeclarativeBase):
+        pass
+
+    return AdminBase
+
+
+def _admin_site_stub() -> Mock:
+    """Minimal admin_site stand-in for building a ModelView.
+
+    Provides the attributes setup_routes touches; empty ``models`` so the
+    display-field resolver falls back to the primary key.
+    """
+    site = Mock()
+    site.models = {}
+    site.admin_authentication.get_current_user.return_value = lambda: None
+    return site
+
+
+@pytest_asyncio.fixture
+async def seeded_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with AsyncSession(engine) as db:
+        db.add_all([Author(id=1, name="Tolkien"), Author(id=2, name="Rowling")])
+        await db.commit()
+        yield db
+    await engine.dispose()
+
+
+def _make_book_view() -> ModelView:
+    async def _dummy_session():  # pragma: no cover - never invoked in this test
+        yield None
+
+    db_config = DatabaseConfig(
+        base=_fresh_admin_base(),
+        session=_dummy_session,
+        admin_db_url="sqlite+aiosqlite:///:memory:",
+    )
+    return ModelView(
+        database_config=db_config,
+        templates=Mock(),
+        model=Book,
+        create_schema=BookCreate,
+        update_schema=BookUpdate,
+        admin_site=_admin_site_stub(),
+        allowed_actions={"view", "create", "update", "delete"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fk_field_becomes_relationship_select(seeded_db):
+    view = _make_book_view()
+    form_fields = _get_form_fields_from_schema(BookCreate)
+
+    await view._apply_relationship_form_fields(form_fields, seeded_db)
+
+    by_name = {f["name"]: f for f in form_fields}
+    author_field = by_name["author_id"]
+    assert author_field["type"] == "relationship_select"
+    assert author_field["related_model_name"] == "Author"
+    assert len(author_field["options"]) == 2
+    assert all("id" in o and "display_name" in o for o in author_field["options"])
+
+    # A non-FK field is left untouched.
+    assert by_name["title"]["type"] != "relationship_select"
+
+
+@pytest.mark.asyncio
+async def test_no_fk_fields_leaves_form_unchanged(seeded_db):
+    """A model with no foreign keys gets no relationship selects."""
+
+    async def _dummy_session():  # pragma: no cover
+        yield None
+
+    db_config = DatabaseConfig(
+        base=_fresh_admin_base(),
+        session=_dummy_session,
+        admin_db_url="sqlite+aiosqlite:///:memory:",
+    )
+    view = ModelView(
+        database_config=db_config,
+        templates=Mock(),
+        model=Author,
+        create_schema=type(
+            "AuthorCreate", (BaseModel,), {"__annotations__": {"name": str}}
+        ),
+        update_schema=type(
+            "AuthorUpdate", (BaseModel,), {"__annotations__": {"name": str}}
+        ),
+        admin_site=_admin_site_stub(),
+        allowed_actions={"view", "create", "update", "delete"},
+    )
+    form_fields = _get_form_fields_from_schema(view.create_schema)
+    await view._apply_relationship_form_fields(form_fields, seeded_db)
+
+    assert all(f["type"] != "relationship_select" for f in form_fields)


### PR DESCRIPTION
# Admin reliability: non-`id` primary keys, session recovery, relationship dropdowns, and action feedback

This branch fixes a cluster of admin-interface bugs reported against 0.4.x and adds two usability features that the relationship work made possible. It teaches the CRUD endpoints to stop assuming every model's primary key is called `id`, stops a single database error from bricking the admin until restart, renders foreign keys as real dropdowns instead of raw number boxes, gives users a success message after an action, and clears out the remaining Pydantic v1 calls. Everything is backend-and-template only — no new dependencies, no schema changes.

---

## Primary key column is no longer assumed to be `id`

The admin's get/update/delete paths passed the record identifier to FastCRUD as `id=<value>` — a hardcoded filter key. For any model whose primary key column is named something else (`job_id`, `uuid`, `pk`), FastCRUD built a query against a column called `id` that doesn't exist, and the update page failed with `Invalid column 'id' for model …`. The model listed fine — only editing broke — which made it look like a rendering bug rather than a key-name bug.

The fix introduces `get_primary_key_name(model)` in `core/db.py`, which reads the model's actual first primary-key column via SQLAlchemy inspection. `ModelView` resolves this once at construction (`self.primary_key_name`) and routes every FastCRUD call through a small `_pk_filter(value)` helper, so a lookup becomes `crud.get(db, **{pk_name: value})` — "where `job_id == <url value>`" — instead of `crud.get(db, id=value)`. The bulk-delete path already derived the key this way; this brings get/update into line.

**Why:** The route path parameter is still uniformly named `{id}` (it's just "the identifier from the URL"), so the *value* source is unchanged — only the *column* it filters on is now correct. `get_primary_key_name` raises rather than silently falling back to `"id"`, so a misconfigured model fails loudly at registration instead of mysteriously at edit time.

---

## Event logging no longer breaks updates on Postgres

With `track_events=True`, the `log_admin_action` decorator records the before/after state of an edited row by fetching it through FastCRUD. It passed the raw path-parameter string straight into the query: `crud.get(db, id=kwargs["id"])`. On SQLite this works because SQLite coerces types, but on Postgres asyncpg binds the string as `VARCHAR` and the engine rejects `integer = character varying`. The resulting 500 was swallowed by the admin's outer handler and surfaced as a redirect to `/admin/login?error=…`, so the symptom looked like an authentication failure on every update of any integer-PK model.

The decorator now converts the identifier to the primary-key type (`convert_id_to_pk_type`) and filters on the real key name (`get_primary_key_name`) in both the previous-state fetch and the post-update fetch — the second of which still used the raw `id` and was the remaining hole after the earlier partial fix.

**Why:** The previous-state fetch had been patched but the post-update fetch had not, so update-with-events still failed on Postgres. Both call sites now share the same conversion, so the symptom is gone regardless of which fetch runs.

---

## A database error no longer poisons the whole admin

`get_admin_db` handed every request the same long-lived `AsyncSession` (created once in `DatabaseConfig.__init__`) and committed it after each use, with no rollback path. When a statement failed — for example creating an `AdminUser` with a duplicate username — that shared session was left in a failed state, and because it was reused by every subsequent request, the admin returned the same traceback for everything until the process was restarted. A single shared `AsyncSession` is also not safe under concurrent requests.

`get_admin_db` now yields a fresh session per request from an `async_sessionmaker`, inside a try/commit/except-rollback block, so a failed statement rolls back and the session is discarded at request end. The create and update endpoints additionally roll back when they catch a database error, so a duplicate-key submission re-renders the form with the error message instead of leaving the session unusable.

**Why:** Per-request sessions are the standard FastAPI pattern and fix both the poisoning and the latent concurrency hazard. The long-lived `get_admin_session()` accessor is untouched — the database session backend still uses it and manages its own rollback — so this change is scoped to the request-handling path.

---

## Foreign keys render as dropdowns

A foreign-key field on a create or update form was generated from the Pydantic schema as a plain integer input, so adding a `Book` meant typing the author's raw numeric id from memory. The relationship metadata to do better already existed (the relationship-options endpoint added with the relationship feature), but nothing fed it into the form.

`ModelView._apply_relationship_form_fields` now walks the model's `BelongsTo` relationships, finds the form field matching each foreign-key column, and turns it into a `relationship_select` populated with the related rows — labelled by the related model's configured `display_field` (falling back to its primary key). The create form, the update form, and both error re-render paths run this enrichment, and the create/update templates gained a `relationship_select` branch that renders the `<select>` and pre-selects the current value on edit.

**Why:** This reuses the existing options endpoint and `display_field` resolution rather than introducing a parallel mechanism, so a foreign key to a model registered with `display_field="name"` shows author names, and one to an unregistered model shows ids — no guessing.

---

## Actions report success

Creating or updating a record redirected to the list view with no confirmation. The reporter of the session-poisoning bug, in fact, only hit a duplicate because the first (successful) create gave no feedback and they assumed it had failed and retried.

The post-action redirect now carries a `?success=created` / `?success=updated` marker, and the list endpoint maps it to a friendly message that the list template renders as a dismissible green banner. The banner auto-dismisses and strips the query parameter from the URL so a manual refresh doesn't re-show it.

---

## Pydantic v1 calls replaced

The codebase still used a handful of Pydantic v1 APIs that emit `PydanticDeprecatedSince20` warnings under Pydantic 2 and are slated for removal in v3: `schema.__fields__` (in the form-field generator and the update path), `model.dict()` (initial-admin creation and the event decorator's user converter). These are now `model_fields` and `model_dump()` respectively, with the user converter preferring `model_dump()` and keeping `.dict()` only as a fallback for genuinely v1-style objects. The `class Config` blocks that remain live inside a docstring example and are not executed, so they were left as-is.

**Why:** These were live deprecation warnings on the runtime path, not just in tests — clearing them keeps the package quiet under Pydantic 2 and ready for v3.

---

## Test Plan

### Automated
- [x] `uv run pytest` — 345 passed (SQLite; Postgres/MySQL container paths run in CI)
- [x] `uv run pytest -W error::DeprecationWarning:pydantic` — 345 passed (no Pydantic v1 deprecations remain on the runtime path)
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy crudadmin` — all clean
- [x] Live end-to-end driver against a running app — 13/13 checks (login, real DB writes, redirects, error handling)

### Primary key not named `id` (#68)
- [x] `get_primary_key_name` returns the real column name for a non-`id` PK model
- [x] `get_primary_key_name` raises for a non-mapped class (no silent `"id"`)
- [x] get / update / delete keyed on the real PK column round-trip against a real DB
- [x] Live: a model with PK `tag_id` loads its update page, updates, and persists

### Event logging on update (#72)
- [x] `log_admin_action` UPDATE/DELETE tests run against a real mapped model
- [x] Live: an update with `track_events=True` records state without erroring (SQLite; the same PK-aware fetch is what fixes the Postgres `integer = varchar` failure)

### Session recovery (#65)
- [x] `get_admin_db` yields a distinct session per request
- [x] A failed statement in one request does not break the next
- [x] Live: a duplicate-key create returns a handled form error (422, not 5xx), the error is shown, and the next create succeeds and persists

### Foreign-key dropdowns (#53)
- [x] A foreign-key field is converted to a `relationship_select` with the related rows as options
- [x] A model with no foreign keys is left unchanged
- [x] Live: the Book create form renders a `<select>` of author names (via `display_field`)

### Success feedback (#71)
- [x] Live: create redirects with `?success=created` and the list renders the success banner; boolean fields round-trip

---

## Dependencies

None new. `async_sessionmaker` comes from the already-required SQLAlchemy 2.0.

## Breaking Changes

- **Models without a primary key are rejected at registration.** `get_primary_key_name` raises `ValueError`, so `add_view()` on a PK-less model now fails immediately and loudly instead of failing later at query time. CRUDAdmin has always required a primary key to manage a model; this just surfaces it sooner.
- **`get_admin_db` no longer shares one session across requests.** It yields a fresh per-request session. Any code that depended on `get_admin_db` carrying state between requests would change behavior — but that was the poisoning bug, not a supported use. The singleton `get_admin_session()` accessor is unchanged.
- **Foreign-key fields are now dropdowns, not free-text id inputs.** Users pick from existing related rows instead of typing an id. The options list is capped (first 100 related rows), so setting a foreign key to a row beyond that cap is not currently possible from the form — relevant only for relationships with very large target tables.
